### PR TITLE
fix: make sure to send posix-style paths to Bump servers

### DIFF
--- a/src/definition.ts
+++ b/src/definition.ts
@@ -9,6 +9,8 @@ import {
   JSONSchema6Object,
 } from 'json-schema';
 import path from 'path';
+import d from 'debug';
+const debug = d('bump-cli:definition');
 
 class SupportedFormat {
   static readonly openapi: Record<string, SpecSchema> = {
@@ -112,7 +114,10 @@ class API {
       absPath.match(/^[a-zA-Z]+\:\\/) || // Windows style filesystem path
       (absPath.match(/^https?:\/\//) && definitionUrl.hostname === refUrl.hostname) // Same domain URLs
     ) {
-      return path.relative(path.dirname(this.location), absPath);
+      const relativePath = path.relative(path.dirname(this.location), absPath);
+      const posixPath = relativePath.replace(new RegExp('\\' + path.sep, 'g'), '/');
+
+      return posixPath;
     } else {
       return absPath;
     }


### PR DESCRIPTION
As a followup to #360, we need to send only posix style paths to our servers as that's how we handle references internally.

The fix in #360 was useful to read filesystem on windows machine (for external references) but was not enough to make sure references in parent or child directory work correctly.

Completely fixes #361